### PR TITLE
Important changes of spring security 4.0.0-CI-SNAPSHOT

### DIFF
--- a/src/main/java/org/thymeleaf/extras/springsecurity3/auth/AuthUtils.java
+++ b/src/main/java/org/thymeleaf/extras/springsecurity3/auth/AuthUtils.java
@@ -40,11 +40,12 @@ import org.springframework.expression.EvaluationContext;
 import org.springframework.expression.Expression;
 import org.springframework.expression.ParseException;
 import org.springframework.security.access.expression.ExpressionUtils;
+import org.springframework.security.access.expression.SecurityExpressionHandler;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.FilterInvocation;
 import org.springframework.security.web.access.WebInvocationPrivilegeEvaluator;
-import org.springframework.security.web.access.expression.WebSecurityExpressionHandler;
+
 import org.springframework.web.context.support.WebApplicationContextUtils;
 import org.thymeleaf.Arguments;
 import org.thymeleaf.TemplateEngine;
@@ -179,7 +180,7 @@ public final class AuthUtils {
                         accessExpression.substring(2, accessExpression.length() - 1) :
                         accessExpression);
         
-        final WebSecurityExpressionHandler handler = getExpressionHandler(servletContext);
+        final SecurityExpressionHandler handler = getExpressionHandler(servletContext);
 
         Expression expressionObject = null;
         try {
@@ -255,22 +256,22 @@ public final class AuthUtils {
     
     
     
-    private static WebSecurityExpressionHandler getExpressionHandler(final ServletContext servletContext) {
+    private static SecurityExpressionHandler getExpressionHandler(final ServletContext servletContext) {
 
         final ApplicationContext ctx =
                 WebApplicationContextUtils.getRequiredWebApplicationContext(servletContext);
         
-        final Map<String, WebSecurityExpressionHandler> expressionHandlers = 
-                ctx.getBeansOfType(WebSecurityExpressionHandler.class);
+        final Map<String, SecurityExpressionHandler> expressionHandlers = 
+                ctx.getBeansOfType(SecurityExpressionHandler.class);
 
-        if (expressionHandlers.size() == 0) {
+        if (expressionHandlers.isEmpty()) {
             throw new TemplateProcessingException(
                     "No visible WebSecurityExpressionHandler instance could be found in the application " +
                     "context. There must be at least one in order to support expressions in Spring Security " +
                     "authorization queries.");
         }
 
-        return (WebSecurityExpressionHandler) expressionHandlers.values().toArray()[0];
+        return (SecurityExpressionHandler) expressionHandlers.values().toArray()[0];
         
     }
     
@@ -290,8 +291,7 @@ public final class AuthUtils {
         
         final boolean result =
                 getPrivilegeEvaluator(servletContext).isAllowed(
-                    request.getContextPath(), url, method, authentication) ? 
-                            true : false;
+                    request.getContextPath(), url, method, authentication);
 
         if (logger.isTraceEnabled()) {
             logger.trace("[THYMELEAF][{}] Checked authorization for URL \"{}\" and method \"{}\" for user \"{}\". " +
@@ -316,7 +316,7 @@ public final class AuthUtils {
         final Map<String, WebInvocationPrivilegeEvaluator> privilegeEvaluators = 
                 ctx.getBeansOfType(WebInvocationPrivilegeEvaluator.class);
 
-        if (privilegeEvaluators.size() == 0) {
+        if (privilegeEvaluators.isEmpty()) {
             throw new TemplateProcessingException(
                     "No visible WebInvocationPrivilegeEvaluator instance could be found in the application " +
                     "context. There must be at least one in order to support URL access checks in " +


### PR DESCRIPTION
Hallo.

Please accept those changes, due to droped deprecated interface WebSecurityExpressionHandler in newest spring security version, which is currently 4.0.0-CI-SNAPSHOT.

WebSecurityExpressionHandler was an extended class with no additional attributes:
https://github.com/spring-projects/spring-security/blob/3.2.x/web/src/main/java/org/springframework/security/web/access/expression/WebSecurityExpressionHandler.java

I replaced the deprecated interface with the default SecurityExpressionHandler:
https://github.com/spring-projects/spring-security/blob/master/core/src/main/java/org/springframework/security/access/expression/SecurityExpressionHandler.java

And successfully tested it locally with spring 4.1.0.RELEASE and 4.0.0-CI-SNAPSHOT.
Before testing with the 2.1.2-SNAPSHOT version of this dependency my webapp was complaining about the missing interface in this changed class. Afterwards it ran as usual.

Best Regards
Tom-Steve Watzke
