### PR TITLE
Fix logging output in AuthUtils

### DIFF
--- a/thymeleaf-extras-springsecurity4/src/main/java/org/thymeleaf/extras/springsecurity4/auth/AuthUtils.java
+++ b/thymeleaf-extras-springsecurity4/src/main/java/org/thymeleaf/extras/springsecurity4/auth/AuthUtils.java
@@ -110,7 +110,7 @@ public final class AuthUtils {
         
         if (logger.isTraceEnabled()) {
             logger.trace("[THYMELEAF][{}] Authentication object of class {} found in context for user \"{}\".",
-                    new Object[] {TemplateEngine.threadIndex(), authentication.getClass().getName()}, authentication.getName());
+                    new Object[] {TemplateEngine.threadIndex(), authentication.getClass().getName(), authentication.getName())};
         }
         
         return authentication;

--- a/thymeleaf-extras-springsecurity4/src/main/java/org/thymeleaf/extras/springsecurity4/auth/AuthUtils.java
+++ b/thymeleaf-extras-springsecurity4/src/main/java/org/thymeleaf/extras/springsecurity4/auth/AuthUtils.java
@@ -110,7 +110,7 @@ public final class AuthUtils {
         
         if (logger.isTraceEnabled()) {
             logger.trace("[THYMELEAF][{}] Authentication object of class {} found in context for user \"{}\".",
-                    new Object[] {TemplateEngine.threadIndex(), authentication.getClass().getName(), authentication.getName())};
+                    new Object[] {TemplateEngine.threadIndex(), authentication.getClass().getName(), authentication.getName()});
         }
         
         return authentication;


### PR DESCRIPTION
AuthUtils.getAuthenticationObject() has a logging statement that ends up calling:

logger.trace(msg, new Object[] {obj1, obj2}, obj3)

But, that doesn't work like the author intended -- it treats the Object[] as one item to log, and obj3 as another. so the first placeholder gets replaced with [obj1, obj2], the second with obj3, and the 3rd placeholder just stays as "{}".
